### PR TITLE
Enable error for unrelated type equality checks

### DIFF
--- a/lib/dart.yaml
+++ b/lib/dart.yaml
@@ -19,6 +19,7 @@ analyzer:
     only_throw_errors: error
     invalid_use_of_internal_member: error
     todo: ignore
+    unrelated_type_equality_checks: error
 
   # Language feature configuration.
   language:


### PR DESCRIPTION
### Description

Added 'unrelated_type_equality_checks' to the analyzer error list in dart.yaml to enforce stricter type safety and prevent equality checks between unrelated types.

### Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
